### PR TITLE
Add [flutter.plugin.platforms] key to [pubspec.yaml]

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
 
 flutter:
   plugin:
-    android:
-      package: com.macif.plugin.sslpinningplugin
-      pluginClass: SslPinningPlugin
-    ios:
-      pluginClass: SslPinningPlugin
-
+    platforms:
+      android:
+        package: com.macif.plugin.sslpinningplugin
+        pluginClass: SslPinningPlugin
+      ios:
+        pluginClass: SslPinningPlugin


### PR DESCRIPTION
The recent version of flutter require `flutteer.plugin.platforms` to be specified in the `pubspec.yaml` file