### PR TITLE
Use StreamSupport (CompletableFuture backport) to fix crash on Android 6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,9 +37,18 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'net.sourceforge.streamsupport:android-retrofuture:1.7.3'
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -148,7 +148,7 @@ class _MyAppState extends State<MyApp> {
                       TextFormField(
                           keyboardType: TextInputType.text,
                           initialValue:
-                              "9D B3 FC A9 17 36 04 27 A2 82 2F BD 06 95 F1 DC 0A 00 9F 72",
+                              "30 23 3C 08 D3 81 53 7E D5 4C D4 02 29 41 C0 CC D0 07 77 FB",
                           decoration: InputDecoration(
                               hintText: 'OO OO OO OO OO OO OO OO OO OO',
                               labelText: 'Fingerprint'),


### PR DESCRIPTION
This PR is about this [issue](https://github.com/macif-dev/ssl_pinning_plugin/issues/16)

The root cause may be some Android N API and not supporting on Android 6 or older devices.

I found a CompleteFuture back port => net.sourceforge.streamsupport:android-retrofuture:1.7.3, and trying to fix this issue.

Please leave some comments no matter you deciding accept this PR or not.
 
Thanks for your effort. 